### PR TITLE
Improve period documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,9 +41,27 @@ Index pages of Xinwenlianbo seem in-accessible online.
 The index pages of this period is accessible at a URL similar to
 http://www.cctv.com/news/xwlb/20020908/index.shtml
 
-### 20090627 - 20100505 (Period B)
+Under this period, there exist multiple sub-periods with similar URL scheme but different HTML layouts.
+
+#### 20020908 - 20041230 (Period A1)
+
+Titles are like `<font class='fs24'>Title</font>`
+
+#### 20041231 - 20060131 (Period A2)
+
+Titles are like `<font class='title_text'>Title</font>`
+
+#### 20060201 - 20070830 (Period A3)
+
+Titles are like `<span class='title'>Title</font>`
+
+#### 20070831 - 20090625 (Period A4)
+
+Title are like `<h1>Title</h1>`
+
+### 20090626 - 20100505 (Period B)
 The index pages of this period is accessible at a URL similar to
-http://news.cctv.com/program/xwlb/20090627.shtml
+http://news.cctv.com/program/xwlb/20090626.shtml
 
 ### 20100506 - 20110405 (Period C)
 The index pages of this period is accessible at a URL similar to

--- a/README.md
+++ b/README.md
@@ -41,19 +41,26 @@ Index pages of Xinwenlianbo seem in-accessible online.
 The index pages of this period is accessible at a URL similar to
 http://news.cctv.com/program/xwlb/20090627.shtml
 
-### 20110406 - now (Period B)
+### 20100506 - 20110405 (Period B)
+The index pages of this period is accessible at a URL similar to
+http://news.cntv.cn/program/xwlb/20100506.shtml
+
+### 20110406 - now (Period C)
 The index page of this period is accessible at a URL similar to
 http://cctv.cntv.cn/lm/xinwenlianbo/20120406.shtml
 
-Under this period, two sub-periods exist:
+Under this period, four sub-periods exist:
 
-#### 20110406 - 20130714 (Period B1)
+#### 20110406 - 20120226 (Period B1)
 Under this period, the anchors linked to the individual reports are inserted by JavaScript, and the HTML page is encoded with GBK.
 
-##### 20120227 - 20120329 (Period B1x)
-A weird period under B1, in which the title is dynamically inserted, but otherwise similar.
+##### 20120227 - 20120329 (Period B2)
+The title is dynamically inserted, but otherwise similar to B1.
 
-#### 20130715 - now (Period B2)
+##### 20120330 - 20130714 (Period B3)
+Same pattern as B1.
+
+#### 20130715 - now (Period B4; last update 20160212)
 Under this period, the anchors are generated on the server side and the page is in UTF-8.
 
 LICENSE

--- a/README.md
+++ b/README.md
@@ -51,16 +51,16 @@ http://cctv.cntv.cn/lm/xinwenlianbo/20120406.shtml
 
 Under this period, four sub-periods exist:
 
-#### 20110406 - 20120226 (Period B1)
+#### 20110406 - 20120226 (Period C1)
 Under this period, the anchors linked to the individual reports are inserted by JavaScript, and the HTML page is encoded with GBK.
 
-##### 20120227 - 20120329 (Period B2)
+#### 20120227 - 20120329 (Period C2)
 The title is dynamically inserted, but otherwise similar to B1.
 
-##### 20120330 - 20130714 (Period B3)
+#### 20120330 - 20130714 (Period C3)
 Same pattern as B1.
 
-#### 20130715 - now (Period B4; last update 20160212)
+#### 20130715 - now (Period C4; last update 20160212)
 Under this period, the anchors are generated on the server side and the page is in UTF-8.
 
 LICENSE

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Requirements
 ----------
 ```
 pip install -r requirements.txt
-```2
+```
 
 How to use
 ----------

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Requirements
 ----------
 ```
 pip install -r requirements.txt
-```
+```2
 
 How to use
 ----------
@@ -37,7 +37,7 @@ Key periods
 ### Before 20090627
 Index pages of Xinwenlianbo seem in-accessible online.
 
-### 20090627 - 20110405 (Period A)
+### 20090627 - 2010505 (Period A)
 The index pages of this period is accessible at a URL similar to
 http://news.cctv.com/program/xwlb/20090627.shtml
 

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Titles are like `<font class='title_text'>Title</font>`
 
 #### 20060201 - 20070830 (Period A3)
 
-Titles are like `<span class='title'>Title</font>`
+Titles are like `<span class='title'>Title</span>`
 
 #### 20070831 - 20090625 (Period A4)
 

--- a/README.md
+++ b/README.md
@@ -34,34 +34,62 @@ To update the documents after the initial collection, run:
 Key periods
 -----------
 
-### Before 20090627
+### On and Before 20020927
 Index pages of Xinwenlianbo seem in-accessible online.
 
-### 20090627 - 2010505 (Period A)
+### 20020908 - 20090626 (Period A)
+The index pages of this period is accessible at a URL similar to
+http://www.cctv.com/news/xwlb/20020908/index.shtml
+
+### 20090627 - 20100505 (Period B)
 The index pages of this period is accessible at a URL similar to
 http://news.cctv.com/program/xwlb/20090627.shtml
 
-### 20100506 - 20110405 (Period B)
+### 20100506 - 20110405 (Period C)
 The index pages of this period is accessible at a URL similar to
 http://news.cntv.cn/program/xwlb/20100506.shtml
 
-### 20110406 - now (Period C)
+### 20110406 - now (Period D)
 The index page of this period is accessible at a URL similar to
 http://cctv.cntv.cn/lm/xinwenlianbo/20120406.shtml
 
 Under this period, four sub-periods exist:
 
-#### 20110406 - 20120226 (Period C1)
+#### 20110406 - 20120226 (Period D1)
 Under this period, the anchors linked to the individual reports are inserted by JavaScript, and the HTML page is encoded with GBK.
 
-#### 20120227 - 20120329 (Period C2)
+#### 20120227 - 20120329 (Period D2)
 The title is dynamically inserted, but otherwise similar to B1.
 
-#### 20120330 - 20130714 (Period C3)
+#### 20120330 - 20130714 (Period D3)
 Same pattern as B1.
 
-#### 20130715 - now (Period C4; last update 20160212)
+#### 20130715 - now (Period D4; last update 20160212)
 Under this period, the anchors are generated on the server side and the page is in UTF-8.
+
+For reference, checkout the JavaScript implementation of the calendar date picker on any Xinwenlianbo page,
+such as <http://news.cntv.cn/program/xwlb/20110105.shtml>. It's something like this:
+```
+var start = new Date(2009, 5, 25, 0, 0, 0);
+//alert("start.getMonth()"+start.getMonth());
+//alert("time="+time.getFullYear()+(time.getMonth()+1)+time.getDate() + "********start=" + start.getFullYear()+(start.getMonth()+1)+start.getDate() + "********now=" + now.getFullYear()+(now.getMonth()+1)+now.getDate());
+if((time < now) && (time > start)){
+var time_1 = year + mon + day;
+if(time_1<20100506){
+str = "http://news.cctv.com/program/xwlb/" + year + mon + day + ".shtml";
+}
+if(time_1>=20100506&&time_1<20110406){
+str = "http://news.cntv.cn/program/xwlb/" + year + mon + day + ".shtml";
+}
+if(time_1>=20110406){
+str = "http://cctv.cntv.cn/lm/xinwenlianbo/" + year + mon + day + ".shtml";
+}
+window.open(str);
+}
+```
+(The above code is for research purpose only and is only distributed under Xinwenlianbo's terms.)
+
+Note that although the code above implies Xinwenlianbo is available since 20090525, it seemsonly after 20090627 are the pages actually accessible.
 
 LICENSE
 --------

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ http://news.cctv.com/program/xwlb/20090626.shtml
 The index pages of this period is accessible at a URL similar to
 http://news.cntv.cn/program/xwlb/20100506.shtml
 
-### 20110406 - now (Period D)
+### 20110406 - 20160220 (Period D)
 The index page of this period is accessible at a URL similar to
 http://cctv.cntv.cn/lm/xinwenlianbo/20120406.shtml
 
@@ -82,28 +82,38 @@ The title is dynamically inserted, but otherwise similar to B1.
 #### 20120330 - 20130714 (Period D3)
 Same pattern as B1.
 
-#### 20130715 - now (Period D4; last update 20160212)
+#### 20130715 - 20160220 (Period D4)
 Under this period, the anchors are generated on the server side and the page is in UTF-8.
 
-For reference, checkout the JavaScript implementation of the calendar date picker on any Xinwenlianbo page,
-such as <http://news.cntv.cn/program/xwlb/20110105.shtml>. It's something like this:
+### 20160202 - now (Period E; last check 20160226)
+Under these period, the index is always at http://tv.cctv.com/lm/xwlb/index.shtml, while the anchors are asynchronoly loaded from a url in the form of http://tv.cctv.com/lm/xwlb/day/20160226.shtml
+
+Note that this period overlaps with Period D4.
+
+For reference, checkout the JavaScript implementation of the calendar date picker on the latest Xinwenlianbo page in 2016,
+such as <http://tv.cctv.com/lm/xwlb/index.shtml>. It's something like this:
 ```
-var start = new Date(2009, 5, 25, 0, 0, 0);
-//alert("start.getMonth()"+start.getMonth());
-//alert("time="+time.getFullYear()+(time.getMonth()+1)+time.getDate() + "********start=" + start.getFullYear()+(start.getMonth()+1)+start.getDate() + "********now=" + now.getFullYear()+(now.getMonth()+1)+now.getDate());
-if((time < now) && (time > start)){
-var time_1 = year + mon + day;
-if(time_1<20100506){
-str = "http://news.cctv.com/program/xwlb/" + year + mon + day + ".shtml";
-}
-if(time_1>=20100506&&time_1<20110406){
-str = "http://news.cntv.cn/program/xwlb/" + year + mon + day + ".shtml";
-}
-if(time_1>=20110406){
-str = "http://cctv.cntv.cn/lm/xinwenlianbo/" + year + mon + day + ".shtml";
-}
-window.open(str);
-}
+		if(time_1<20100506){
+			str = "http://news.cctv.com/program/xwlb/" + year + mon + day + ".shtml";//这里的地址使用他之前的地址域名
+			window.open(str);
+		}
+		if(time_1>=20100506&&time_1<20110406){
+			str = "http://news.cntv.cn/program/xwlb/" + year + mon + day + ".shtml";//这里的地址使用他之前的地址域名，具体域名可参考相关栏目的旧时间表JS写法
+			window.open(str);
+		}
+		if(time_1>=20110406&&time_1<20130709){
+		    //alert("http://cctv.cntv.cn/program/C29201/" + year + mon + day + ".shtml");
+			str = "http://cctv.cntv.cn/lm/xinwenlianbo/" + year + mon + day + ".shtml";//这里的地址使用他之前的新地址域名
+			window.open(str);
+		}
+		if(time_1>=20130709&&time_1<20160203){
+			str = "http://cctv.cntv.cn/lm/xinwenlianbo/" + year + mon + day + ".shtml";//这里的地址使用新地址域名例如http://news.cntv.cn/lm/xinwenlianbotest/20130515.shtml
+			window.open(str);
+		}
+		
+		if(time_1>=20160203){
+		  //Code skipped
+  	}
 ```
 (The above code is for research purpose only and is only distributed under Xinwenlianbo's terms.)
 

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Key periods
 ### On and Before 20020927
 Index pages of Xinwenlianbo seem in-accessible online.
 
-### 20020908 - 20090626 (Period A)
+### 20020908 - 20090625 (Period A)
 The index pages of this period is accessible at a URL similar to
 http://www.cctv.com/news/xwlb/20020908/index.shtml
 


### PR DESCRIPTION
- Since 20160220, Xinwenlianbo website changed scheme again, which is reflected by this PR.
- Also added was the period from 2002 to 2009, which had been assumed missing.
- This PR also includes clarifications on the old schemes.
